### PR TITLE
SafeConnect: add survivor notification center

### DIFF
--- a/safeconnect/app/notifications/page.tsx
+++ b/safeconnect/app/notifications/page.tsx
@@ -1,0 +1,175 @@
+"use client"
+
+import Link from "next/link"
+import { useCallback, useEffect, useMemo, useState } from "react"
+import ProtectedRoute from "@/components/ProtectedRoute"
+import { supabase } from "@/lib/supabase"
+
+type SurvivorNotification = {
+  id: string
+  exchange_id: string | null
+  template: string
+  payload: Record<string, unknown> | null
+  priority: string | null
+  status: string
+  acknowledged_at: string | null
+  created_at: string
+}
+
+function titleFor(template: string) {
+  const labels: Record<string, string> = {
+    survivor_payment_confirmed: "Payment confirmed",
+    survivor_courier_assigned: "Courier assigned",
+    survivor_courier_enroute: "Courier en route",
+    survivor_delivery_completed: "Delivery completed",
+    survivor_request_canceled: "Request canceled",
+    survivor_tracking_update: "Tracking update",
+    survivor_tracking_delivered: "Delivered tracking update",
+  }
+
+  return labels[template] ?? template.replace(/_/g, " ")
+}
+
+function shortId(id?: string | null) {
+  return id ? id.slice(0, 8).toUpperCase() : "-"
+}
+
+function NotificationsContent() {
+  const [notifications, setNotifications] = useState<SurvivorNotification[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState("")
+
+  const unreadCount = useMemo(
+    () => notifications.filter((item) => !item.acknowledged_at).length,
+    [notifications]
+  )
+
+  const loadNotifications = useCallback(async () => {
+    setError("")
+    const { data, error: loadError } = await supabase
+      .from("notification_events")
+      .select("id,exchange_id,template,payload,priority,status,acknowledged_at,created_at")
+      .order("created_at", { ascending: false })
+      .limit(40)
+
+    if (loadError) {
+      setError(loadError.message)
+      setLoading(false)
+      return
+    }
+
+    setNotifications((data ?? []) as SurvivorNotification[])
+    setLoading(false)
+  }, [])
+
+  useEffect(() => {
+    loadNotifications()
+  }, [loadNotifications])
+
+  useEffect(() => {
+    const channel = supabase
+      .channel("survivor-notification-center")
+      .on(
+        "postgres_changes",
+        { event: "INSERT", schema: "public", table: "notification_events" },
+        (payload) => {
+          const row = payload.new as SurvivorNotification
+          setNotifications((current) => [row, ...current.filter((item) => item.id !== row.id)].slice(0, 40))
+        }
+      )
+      .subscribe()
+
+    return () => {
+      supabase.removeChannel(channel)
+    }
+  }, [])
+
+  async function acknowledge(id: string) {
+    const { error: updateError } = await supabase
+      .from("notification_events")
+      .update({ acknowledged_at: new Date().toISOString() })
+      .eq("id", id)
+
+    if (updateError) {
+      setError(updateError.message)
+      return
+    }
+
+    setNotifications((current) =>
+      current.map((item) => item.id === id ? { ...item, acknowledged_at: new Date().toISOString() } : item)
+    )
+  }
+
+  return (
+    <div className="page-container space-y-6 animate-fade-in">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-widest text-safe-500">Survivor Portal</p>
+          <h1 className="text-3xl font-bold text-safe-900">Notification Center</h1>
+          <p className="text-sm text-safe-500 mt-1">Payment, courier, tracking, and delivery updates in one secure place.</p>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <Link href="/request" className="btn-secondary text-sm px-4 py-2">Back to Requests</Link>
+          <button type="button" onClick={loadNotifications} className="btn-primary text-sm px-4 py-2">Refresh</button>
+        </div>
+      </div>
+
+      <div className="card flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <p className="text-sm font-semibold text-safe-900">Unread updates</p>
+          <p className="text-xs text-safe-500">Acknowledge notifications after you review them.</p>
+        </div>
+        <span className="rounded-full bg-red-100 px-4 py-2 text-sm font-bold text-red-700">{unreadCount} unread</span>
+      </div>
+
+      {error ? <div className="alert-error">{error}</div> : null}
+
+      {loading ? (
+        <div className="card text-sm text-safe-500">Loading notifications...</div>
+      ) : notifications.length === 0 ? (
+        <div className="card text-sm text-safe-500">No notifications yet.</div>
+      ) : (
+        <div className="space-y-3">
+          {notifications.map((item) => (
+            <article key={item.id} className={`card border ${item.acknowledged_at ? "border-safe-100 opacity-80" : "border-red-200"}`}>
+              <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                <div>
+                  <div className="flex flex-wrap items-center gap-2">
+                    <h2 className="text-lg font-bold text-safe-900 capitalize">{titleFor(item.template)}</h2>
+                    {!item.acknowledged_at ? <span className="badge-pending">New</span> : <span className="badge-done">Acknowledged</span>}
+                    {item.priority === "high" ? <span className="rounded-full bg-red-100 px-2 py-1 text-xs font-bold text-red-700">High</span> : null}
+                  </div>
+                  <p className="mt-1 text-xs text-safe-400">Request #{shortId(item.exchange_id)} • {new Date(item.created_at).toLocaleString()}</p>
+                </div>
+                <div className="flex flex-wrap gap-2">
+                  {item.exchange_id ? (
+                    <Link href={`/track/${item.exchange_id}`} className="btn-secondary text-xs px-3 py-2">Track Request</Link>
+                  ) : null}
+                  {!item.acknowledged_at ? (
+                    <button type="button" onClick={() => acknowledge(item.id)} className="btn-primary text-xs px-3 py-2">Acknowledge</button>
+                  ) : null}
+                </div>
+              </div>
+
+              <div className="mt-3 grid gap-2 text-sm text-safe-700 sm:grid-cols-2">
+                {item.payload?.pickup ? <p><span className="font-semibold text-safe-900">Pickup:</span> {String(item.payload.pickup)}</p> : null}
+                {item.payload?.dropoff ? <p><span className="font-semibold text-safe-900">Dropoff:</span> {String(item.payload.dropoff)}</p> : null}
+                {item.payload?.status ? <p><span className="font-semibold text-safe-900">Status:</span> {String(item.payload.status)}</p> : null}
+                {item.payload?.paymentStatus ? <p><span className="font-semibold text-safe-900">Payment:</span> {String(item.payload.paymentStatus)}</p> : null}
+                {item.payload?.trackingStatus ? <p><span className="font-semibold text-safe-900">Tracking:</span> {String(item.payload.trackingStatus)}</p> : null}
+              </div>
+            </article>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default function NotificationsPage() {
+  return (
+    <ProtectedRoute requiredRole="survivor" loadingLabel="Opening notification center...">
+      <NotificationsContent />
+    </ProtectedRoute>
+  )
+}

--- a/safeconnect/supabase/migrations/027_survivor_notifications.sql
+++ b/safeconnect/supabase/migrations/027_survivor_notifications.sql
@@ -1,0 +1,153 @@
+create or replace function public.create_survivor_exchange_status_alert()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  survivor_email text;
+  template_name text;
+  priority_name text := 'normal';
+  sound_name text := 'standard_request';
+begin
+  if old.status is not distinct from new.status
+    and old.payment_status is not distinct from new.payment_status
+    and old.courier_id is not distinct from new.courier_id then
+    return new;
+  end if;
+
+  select email into survivor_email
+  from public.users
+  where id = new.user_id;
+
+  if survivor_email is null then
+    return new;
+  end if;
+
+  if old.payment_status is distinct from new.payment_status and new.payment_status = 'paid' then
+    template_name := 'survivor_payment_confirmed';
+  elsif old.courier_id is distinct from new.courier_id and new.courier_id is not null then
+    template_name := 'survivor_courier_assigned';
+  elsif old.status is distinct from new.status and new.status = 'in_transit' then
+    template_name := 'survivor_courier_enroute';
+  elsif old.status is distinct from new.status and new.status = 'completed' then
+    template_name := 'survivor_delivery_completed';
+    priority_name := 'high';
+    sound_name := 'delivery_complete';
+  elsif old.status is distinct from new.status and new.status = 'canceled' then
+    template_name := 'survivor_request_canceled';
+    priority_name := 'high';
+    sound_name := 'request_canceled';
+  else
+    return new;
+  end if;
+
+  insert into public.notification_events (
+    user_id,
+    exchange_id,
+    channel,
+    recipient,
+    template,
+    payload,
+    status,
+    priority,
+    sound_key
+  ) values (
+    new.user_id,
+    new.id,
+    'in_app',
+    survivor_email,
+    template_name,
+    jsonb_build_object(
+      'exchangeId', new.id,
+      'requestCode', upper(left(new.id::text, 8)),
+      'status', new.status,
+      'paymentStatus', new.payment_status,
+      'pickup', new.pickup,
+      'dropoff', new.dropoff,
+      'updatedAt', now()
+    ),
+    'queued',
+    priority_name,
+    sound_name
+  );
+
+  return new;
+end;
+$$;
+
+drop trigger if exists create_survivor_exchange_status_alert on public.exchanges;
+create trigger create_survivor_exchange_status_alert
+after update on public.exchanges
+for each row execute function public.create_survivor_exchange_status_alert();
+
+create or replace function public.create_survivor_tracking_alert()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  survivor_id uuid;
+  survivor_email text;
+  request_pickup text;
+  request_dropoff text;
+  template_name text;
+begin
+  select e.user_id, e.pickup, e.dropoff, u.email
+  into survivor_id, request_pickup, request_dropoff, survivor_email
+  from public.exchanges e
+  left join public.users u on u.id = e.user_id
+  where e.id = new.request_id;
+
+  if survivor_id is null then
+    return new;
+  end if;
+
+  if new.status = 'delivered' then
+    template_name := 'survivor_tracking_delivered';
+  else
+    template_name := 'survivor_tracking_update';
+  end if;
+
+  insert into public.notification_events (
+    user_id,
+    exchange_id,
+    channel,
+    recipient,
+    template,
+    payload,
+    status,
+    priority,
+    sound_key
+  ) values (
+    survivor_id,
+    new.request_id,
+    'in_app',
+    survivor_email,
+    template_name,
+    jsonb_build_object(
+      'exchangeId', new.request_id,
+      'requestCode', upper(left(new.request_id::text, 8)),
+      'trackingStatus', new.status,
+      'pickup', request_pickup,
+      'dropoff', request_dropoff,
+      'routeLat', new.route_lat,
+      'routeLng', new.route_lng,
+      'updatedAt', new.updated_at
+    ),
+    'queued',
+    case when new.status = 'delivered' then 'high' else 'normal' end,
+    case when new.status = 'delivered' then 'delivery_complete' else 'tracking_update' end
+  );
+
+  return new;
+end;
+$$;
+
+drop trigger if exists create_survivor_tracking_alert on public.tracking;
+create trigger create_survivor_tracking_alert
+after insert on public.tracking
+for each row execute function public.create_survivor_tracking_alert();
+
+notify pgrst, 'reload schema';


### PR DESCRIPTION
## Summary
- Adds backend triggers that create survivor in-app notifications for payment confirmed, courier assigned, courier en route, delivery completed, request canceled, and tracking updates.
- Adds a protected `/notifications` page for survivors to view, track, and acknowledge updates.
- Keeps survivor notification work separate from the existing request page to reduce risk.

## Test plan
- Apply migration 027 in Supabase.
- Sign in as survivor and open `/notifications`.
- Update a request status/payment/courier assignment and confirm notification rows appear.
- Insert a tracking row and confirm a survivor tracking notification appears.
- Acknowledge a notification and confirm it updates.