### PR TITLE
SafeConnect: add real proof photo uploads

### DIFF
--- a/safeconnect/components/courier/CourierAssignmentDetail.tsx
+++ b/safeconnect/components/courier/CourierAssignmentDetail.tsx
@@ -21,8 +21,11 @@ type ServiceProof = {
   id: string
   proof_type: ProofType
   signer_name: string | null
+  storage_path: string | null
   created_at: string
 }
+
+const PROOF_BUCKET = "safeconnect-private-documents"
 
 const REQUIRED_PROOFS: { type: ProofType; label: string }[] = [
   { type: "pickup_photo", label: "Pickup photo" },
@@ -33,6 +36,10 @@ const REQUIRED_PROOFS: { type: ProofType; label: string }[] = [
 
 function isSignatureProof(type: ProofType) {
   return type === "pickup_signature" || type === "dropoff_signature"
+}
+
+function isPhotoProof(type: ProofType) {
+  return type === "pickup_photo" || type === "dropoff_photo"
 }
 
 async function getCurrentCoords() {
@@ -57,6 +64,7 @@ export default function CourierAssignmentDetail({ assignment }: { assignment: As
   const [error, setError] = useState("")
   const [proofs, setProofs] = useState<ServiceProof[]>([])
   const [signerNames, setSignerNames] = useState<Record<string, string>>({})
+  const [selectedFiles, setSelectedFiles] = useState<Record<string, File | null>>({})
   const [savingProof, setSavingProof] = useState("")
 
   const proofMap = useMemo(() => {
@@ -71,7 +79,7 @@ export default function CourierAssignmentDetail({ assignment }: { assignment: As
   async function loadProofs() {
     const { data, error: proofError } = await supabase
       .from("exchange_service_proofs")
-      .select("id,proof_type,signer_name,created_at")
+      .select("id,proof_type,signer_name,storage_path,created_at")
       .eq("exchange_id", assignment.id)
       .order("created_at", { ascending: false })
 
@@ -86,6 +94,23 @@ export default function CourierAssignmentDetail({ assignment }: { assignment: As
   useEffect(() => {
     loadProofs()
   }, [assignment.id])
+
+  async function uploadProofFile(proofType: ProofType, file: File) {
+    const extension = file.name.split(".").pop()?.toLowerCase() || "jpg"
+    const cleanExtension = extension.replace(/[^a-z0-9]/g, "") || "jpg"
+    const storagePath = `exchange-proofs/${assignment.id}/${proofType}-${Date.now()}.${cleanExtension}`
+
+    const { error: uploadError } = await supabase.storage
+      .from(PROOF_BUCKET)
+      .upload(storagePath, file, {
+        cacheControl: "3600",
+        upsert: false,
+        contentType: file.type || "image/jpeg",
+      })
+
+    if (uploadError) throw uploadError
+    return storagePath
+  }
 
   async function saveProof(proofType: ProofType) {
     setSavingProof(proofType)
@@ -106,30 +131,46 @@ export default function CourierAssignmentDetail({ assignment }: { assignment: As
       return
     }
 
-    const coords = await getCurrentCoords()
-    const { error: insertError } = await supabase.from("exchange_service_proofs").insert({
-      exchange_id: assignment.id,
-      courier_id: authData.user.id,
-      proof_type: proofType,
-      signer_name: signerName,
-      signature_payload: isSignatureProof(proofType)
-        ? JSON.stringify({ method: "typed_signature", signerName, signedAt: new Date().toISOString() })
-        : null,
-      latitude: coords?.latitude ?? null,
-      longitude: coords?.longitude ?? null,
-      notes: `${proofType.replace(/_/g, " ")} confirmed by courier.`,
-    })
-
-    if (insertError) {
-      setError(insertError.message)
+    const file = selectedFiles[proofType]
+    if (isPhotoProof(proofType) && !file) {
+      setError("Choose or take a photo before saving this proof.")
       setSavingProof("")
       return
     }
 
-    setSignerNames((prev) => ({ ...prev, [proofType]: "" }))
-    setMessage(`${proofType.replace(/_/g, " ")} saved.`)
-    setSavingProof("")
-    await loadProofs()
+    try {
+      const coords = await getCurrentCoords()
+      const storagePath = file ? await uploadProofFile(proofType, file) : null
+
+      const { error: insertError } = await supabase.from("exchange_service_proofs").insert({
+        exchange_id: assignment.id,
+        courier_id: authData.user.id,
+        proof_type: proofType,
+        signer_name: signerName,
+        storage_bucket: storagePath ? PROOF_BUCKET : null,
+        storage_path: storagePath,
+        signature_payload: isSignatureProof(proofType)
+          ? JSON.stringify({ method: "typed_signature", signerName, signedAt: new Date().toISOString() })
+          : null,
+        latitude: coords?.latitude ?? null,
+        longitude: coords?.longitude ?? null,
+        notes: storagePath
+          ? `${proofType.replace(/_/g, " ")} photo uploaded by courier.`
+          : `${proofType.replace(/_/g, " ")} confirmed by courier.`,
+      })
+
+      if (insertError) throw insertError
+
+      setSignerNames((prev) => ({ ...prev, [proofType]: "" }))
+      setSelectedFiles((prev) => ({ ...prev, [proofType]: null }))
+      setMessage(`${proofType.replace(/_/g, " ")} saved.`)
+      await loadProofs()
+    } catch (proofError) {
+      const detail = proofError instanceof Error ? proofError.message : "Unable to save proof."
+      setError(detail)
+    } finally {
+      setSavingProof("")
+    }
   }
 
   async function runAction(action: CourierAction) {
@@ -200,13 +241,14 @@ export default function CourierAssignmentDetail({ assignment }: { assignment: As
         <div>
           <p className="text-xs font-semibold uppercase tracking-widest text-amber-700">Proof of Service</p>
           <h2 className="text-xl font-semibold text-slate-900">Pickup and drop-off proof package</h2>
-          <p className="text-sm text-slate-700">Confirm all four proof records before marking the assignment delivered.</p>
+          <p className="text-sm text-slate-700">Upload photos and confirm signatures before marking the assignment delivered.</p>
         </div>
 
         <div className="grid gap-4 md:grid-cols-2">
           {REQUIRED_PROOFS.map((proof) => {
             const saved = proofMap[proof.type]
             const signature = isSignatureProof(proof.type)
+            const photo = isPhotoProof(proof.type)
             return (
               <div key={proof.type} className="rounded-2xl border border-white bg-white p-4 shadow-sm">
                 <div className="flex items-start justify-between gap-3">
@@ -215,6 +257,19 @@ export default function CourierAssignmentDetail({ assignment }: { assignment: As
                     {saved ? "Saved" : "Needed"}
                   </span>
                 </div>
+                {photo ? (
+                  <div className="mt-4 space-y-2">
+                    <input
+                      type="file"
+                      accept="image/*"
+                      capture="environment"
+                      disabled={Boolean(saved) || savingProof !== ""}
+                      onChange={(event) => setSelectedFiles((prev) => ({ ...prev, [proof.type]: event.target.files?.[0] ?? null }))}
+                      className="block w-full text-sm text-slate-600 file:mr-3 file:rounded-xl file:border-0 file:bg-slate-900 file:px-3 file:py-2 file:text-sm file:font-semibold file:text-white"
+                    />
+                    {selectedFiles[proof.type] ? <p className="text-xs text-slate-500">Ready: {selectedFiles[proof.type]?.name}</p> : null}
+                  </div>
+                ) : null}
                 {signature ? (
                   <input
                     className="mt-4 w-full rounded-xl border border-slate-200 px-3 py-2 text-sm"

--- a/safeconnect/supabase/migrations/030_proof_photo_storage.sql
+++ b/safeconnect/supabase/migrations/030_proof_photo_storage.sql
@@ -1,0 +1,80 @@
+insert into storage.buckets (
+  id,
+  name,
+  public,
+  file_size_limit,
+  allowed_mime_types
+) values (
+  'safeconnect-private-documents',
+  'safeconnect-private-documents',
+  false,
+  10485760,
+  array['image/jpeg', 'image/png', 'image/webp', 'image/heic', 'image/heif']
+)
+on conflict (id) do update set
+  public = excluded.public,
+  file_size_limit = excluded.file_size_limit,
+  allowed_mime_types = excluded.allowed_mime_types;
+
+drop policy if exists "SafeConnect proof files are viewable by related parties" on storage.objects;
+create policy "SafeConnect proof files are viewable by related parties"
+on storage.objects
+for select
+to authenticated
+using (
+  bucket_id = 'safeconnect-private-documents'
+  and (storage.foldername(name))[1] = 'exchange-proofs'
+  and (
+    public.is_safeconnect_admin()
+    or exists (
+      select 1
+      from public.exchanges e
+      where e.id::text = (storage.foldername(name))[2]
+      and (e.user_id = auth.uid() or e.courier_id = auth.uid())
+    )
+  )
+);
+
+drop policy if exists "Assigned couriers can upload SafeConnect proof files" on storage.objects;
+create policy "Assigned couriers can upload SafeConnect proof files"
+on storage.objects
+for insert
+to authenticated
+with check (
+  bucket_id = 'safeconnect-private-documents'
+  and (storage.foldername(name))[1] = 'exchange-proofs'
+  and exists (
+    select 1
+    from public.exchanges e
+    where e.id::text = (storage.foldername(name))[2]
+    and e.courier_id = auth.uid()
+  )
+);
+
+drop policy if exists "Assigned couriers can update SafeConnect proof files" on storage.objects;
+create policy "Assigned couriers can update SafeConnect proof files"
+on storage.objects
+for update
+to authenticated
+using (
+  bucket_id = 'safeconnect-private-documents'
+  and (storage.foldername(name))[1] = 'exchange-proofs'
+  and exists (
+    select 1
+    from public.exchanges e
+    where e.id::text = (storage.foldername(name))[2]
+    and e.courier_id = auth.uid()
+  )
+)
+with check (
+  bucket_id = 'safeconnect-private-documents'
+  and (storage.foldername(name))[1] = 'exchange-proofs'
+  and exists (
+    select 1
+    from public.exchanges e
+    where e.id::text = (storage.foldername(name))[2]
+    and e.courier_id = auth.uid()
+  )
+);
+
+notify pgrst, 'reload schema';


### PR DESCRIPTION
Adds real courier proof photo upload support for pickup and drop-off proof records.

Changes:
- Adds Supabase Storage migration for private SafeConnect proof photos.
- Creates/updates `safeconnect-private-documents` bucket.
- Adds storage policies for assigned couriers and related parties/admins.
- Updates courier assignment proof checklist so pickup/drop-off photo proofs require a selected image file.
- Uploads proof photos under `exchange-proofs/{exchange_id}/...` and saves storage bucket/path on `exchange_service_proofs`.

Note:
- Admin proof image preview will be added in a follow-up PR. This PR focuses on upload/storage foundation.

Test:
- Apply migration 030 in Supabase SQL Editor.
- Create or assign a paid request to a courier.
- Open the courier assignment detail page.
- Choose/take pickup and drop-off photos.
- Save all four proof records.
- Confirm `exchange_service_proofs.storage_path` is filled for photo proofs.