### PR TITLE
SafeConnect: fix courier typed signature proof saving

### DIFF
--- a/safeconnect/app/api/courier/assignments/[id]/proofs/route.ts
+++ b/safeconnect/app/api/courier/assignments/[id]/proofs/route.ts
@@ -1,0 +1,134 @@
+import { NextResponse } from "next/server"
+import { getServerRouteSupabase } from "@/lib/serverRouteSupabase"
+
+type ProofType = "pickup_photo" | "pickup_signature" | "dropoff_photo" | "dropoff_signature"
+
+const ALLOWED_PROOF_TYPES: ProofType[] = [
+  "pickup_photo",
+  "pickup_signature",
+  "dropoff_photo",
+  "dropoff_signature",
+]
+
+function isProofType(value: unknown): value is ProofType {
+  return typeof value === "string" && ALLOWED_PROOF_TYPES.includes(value as ProofType)
+}
+
+function isSignatureProof(value: ProofType) {
+  return value === "pickup_signature" || value === "dropoff_signature"
+}
+
+async function requireCourier() {
+  const supabase = getServerRouteSupabase()
+
+  if (!supabase) {
+    return { supabase: null, userId: null, error: "Supabase route client unavailable.", status: 503 }
+  }
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    return { supabase, userId: null, error: "Unauthorized", status: 401 }
+  }
+
+  const { data: roleRow } = await supabase.from("users").select("role").eq("id", user.id).single()
+
+  if (roleRow?.role !== "courier") {
+    return { supabase, userId: user.id, error: "Courier access required.", status: 403 }
+  }
+
+  return { supabase, userId: user.id, error: null as string | null, status: 200 }
+}
+
+export async function POST(
+  request: Request,
+  context: { params: { id: string } }
+) {
+  const auth = await requireCourier()
+
+  if (auth.error || !auth.supabase || !auth.userId) {
+    return NextResponse.json({ error: auth.error }, { status: auth.status })
+  }
+
+  const exchangeId = context.params.id
+
+  if (!exchangeId) {
+    return NextResponse.json({ error: "Assignment id is required." }, { status: 400 })
+  }
+
+  const body = (await request.json().catch(() => ({}))) as {
+    proofType?: unknown
+    signerName?: unknown
+    storageBucket?: unknown
+    storagePath?: unknown
+    latitude?: unknown
+    longitude?: unknown
+  }
+
+  if (!isProofType(body.proofType)) {
+    return NextResponse.json({ error: "Invalid proof type." }, { status: 400 })
+  }
+
+  const proofType = body.proofType
+  const signerName = typeof body.signerName === "string" ? body.signerName.trim() : ""
+  const storageBucket = typeof body.storageBucket === "string" ? body.storageBucket : null
+  const storagePath = typeof body.storagePath === "string" ? body.storagePath : null
+  const latitude = typeof body.latitude === "number" ? body.latitude : null
+  const longitude = typeof body.longitude === "number" ? body.longitude : null
+
+  if (isSignatureProof(proofType) && !signerName) {
+    return NextResponse.json({ error: "Signer name is required for signature proofs." }, { status: 400 })
+  }
+
+  const { data: exchange, error: exchangeError } = await auth.supabase
+    .from("exchanges")
+    .select("id,courier_id")
+    .eq("id", exchangeId)
+    .eq("courier_id", auth.userId)
+    .single()
+
+  if (exchangeError || !exchange) {
+    return NextResponse.json({ error: "Assignment not found for this courier." }, { status: 404 })
+  }
+
+  const { data: existing } = await auth.supabase
+    .from("exchange_service_proofs")
+    .select("id")
+    .eq("exchange_id", exchangeId)
+    .eq("courier_id", auth.userId)
+    .eq("proof_type", proofType)
+    .maybeSingle()
+
+  if (existing?.id) {
+    return NextResponse.json({ error: `${proofType.replace(/_/g, " ")} has already been saved.` }, { status: 409 })
+  }
+
+  const { data: proofRow, error: insertError } = await auth.supabase
+    .from("exchange_service_proofs")
+    .insert({
+      exchange_id: exchangeId,
+      courier_id: auth.userId,
+      proof_type: proofType,
+      signer_name: signerName || null,
+      storage_bucket: storageBucket,
+      storage_path: storagePath,
+      signature_payload: isSignatureProof(proofType)
+        ? JSON.stringify({ method: "typed_signature", signerName, signedAt: new Date().toISOString() })
+        : null,
+      latitude,
+      longitude,
+      notes: storagePath
+        ? `${proofType.replace(/_/g, " ")} photo uploaded by courier.`
+        : `${proofType.replace(/_/g, " ")} confirmed by courier.`,
+    })
+    .select("id,proof_type,signer_name,storage_path,created_at")
+    .single()
+
+  if (insertError) {
+    return NextResponse.json({ error: insertError.message }, { status: 500 })
+  }
+
+  return NextResponse.json({ success: true, proof: proofRow })
+}

--- a/safeconnect/components/courier/CourierAssignmentDetail.tsx
+++ b/safeconnect/components/courier/CourierAssignmentDetail.tsx
@@ -117,14 +117,7 @@ export default function CourierAssignmentDetail({ assignment }: { assignment: As
     setMessage("")
     setError("")
 
-    const { data: authData } = await supabase.auth.getUser()
-    if (!authData.user) {
-      setError("Please sign in again before saving proof.")
-      setSavingProof("")
-      return
-    }
-
-    const signerName = signerNames[proofType]?.trim() || null
+    const signerName = signerNames[proofType]?.trim() || ""
     if (isSignatureProof(proofType) && !signerName) {
       setError("Enter the signer name before saving this proof.")
       setSavingProof("")
@@ -142,24 +135,23 @@ export default function CourierAssignmentDetail({ assignment }: { assignment: As
       const coords = await getCurrentCoords()
       const storagePath = file ? await uploadProofFile(proofType, file) : null
 
-      const { error: insertError } = await supabase.from("exchange_service_proofs").insert({
-        exchange_id: assignment.id,
-        courier_id: authData.user.id,
-        proof_type: proofType,
-        signer_name: signerName,
-        storage_bucket: storagePath ? PROOF_BUCKET : null,
-        storage_path: storagePath,
-        signature_payload: isSignatureProof(proofType)
-          ? JSON.stringify({ method: "typed_signature", signerName, signedAt: new Date().toISOString() })
-          : null,
-        latitude: coords?.latitude ?? null,
-        longitude: coords?.longitude ?? null,
-        notes: storagePath
-          ? `${proofType.replace(/_/g, " ")} photo uploaded by courier.`
-          : `${proofType.replace(/_/g, " ")} confirmed by courier.`,
+      const response = await fetch(`/api/courier/assignments/${assignment.id}/proofs`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          proofType,
+          signerName,
+          storageBucket: storagePath ? PROOF_BUCKET : null,
+          storagePath,
+          latitude: coords?.latitude ?? null,
+          longitude: coords?.longitude ?? null,
+        }),
       })
 
-      if (insertError) throw insertError
+      const payload = (await response.json().catch(() => ({}))) as { error?: string }
+      if (!response.ok) {
+        throw new Error(payload.error || "Unable to save proof.")
+      }
 
       setSignerNames((prev) => ({ ...prev, [proofType]: "" }))
       setSelectedFiles((prev) => ({ ...prev, [proofType]: null }))


### PR DESCRIPTION
Fixes courier typed signature proof saving by routing proof inserts through a courier-authenticated API endpoint.

Changes:
- Adds `/api/courier/assignments/[id]/proofs` POST route.
- Validates courier role and assignment ownership before saving proof rows.
- Prevents duplicate proof records per courier/request/proof type.
- Updates courier assignment proof checklist to save photo and signature proof records through the API route.
- Keeps Supabase Storage upload for photo files on the client, then passes storage bucket/path to the proof API.

Test:
- Create/assign a paid request to courier.
- Save pickup photo.
- Save pickup signature.
- Save drop-off photo.
- Save drop-off signature.
- Confirm all four records appear in `exchange_service_proofs` without SQL repair.
- Confirm Mark Delivered unlocks and completes delivery.