### PR TITLE
SafeConnect: repair courier proof save authentication

### DIFF
--- a/safeconnect/app/api/courier/assignments/[id]/proofs/route.ts
+++ b/safeconnect/app/api/courier/assignments/[id]/proofs/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server"
+import { createClient } from "@supabase/supabase-js"
 import { getServerRouteSupabase } from "@/lib/serverRouteSupabase"
 
 type ProofType = "pickup_photo" | "pickup_signature" | "dropoff_photo" | "dropoff_signature"
@@ -18,8 +19,34 @@ function isSignatureProof(value: ProofType) {
   return value === "pickup_signature" || value === "dropoff_signature"
 }
 
-async function requireCourier() {
-  const supabase = getServerRouteSupabase()
+function getProofSupabase(request: Request) {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL
+  const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+  const authorization = request.headers.get("authorization")
+
+  if (!url || !anonKey) {
+    return null
+  }
+
+  if (authorization?.toLowerCase().startsWith("bearer ")) {
+    return createClient(url, anonKey, {
+      global: {
+        headers: {
+          Authorization: authorization,
+        },
+      },
+      auth: {
+        persistSession: false,
+        autoRefreshToken: false,
+      },
+    })
+  }
+
+  return getServerRouteSupabase()
+}
+
+async function requireCourier(request: Request) {
+  const supabase = getProofSupabase(request)
 
   if (!supabase) {
     return { supabase: null, userId: null, error: "Supabase route client unavailable.", status: 503 }
@@ -46,7 +73,7 @@ export async function POST(
   request: Request,
   context: { params: { id: string } }
 ) {
-  const auth = await requireCourier()
+  const auth = await requireCourier(request)
 
   if (auth.error || !auth.supabase || !auth.userId) {
     return NextResponse.json({ error: auth.error }, { status: auth.status })

--- a/safeconnect/components/courier/CourierAssignmentDetail.tsx
+++ b/safeconnect/components/courier/CourierAssignmentDetail.tsx
@@ -134,10 +134,15 @@ export default function CourierAssignmentDetail({ assignment }: { assignment: As
     try {
       const coords = await getCurrentCoords()
       const storagePath = file ? await uploadProofFile(proofType, file) : null
+      const { data: sessionData } = await supabase.auth.getSession()
+      const accessToken = sessionData.session?.access_token
 
       const response = await fetch(`/api/courier/assignments/${assignment.id}/proofs`, {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
+        headers: {
+          "Content-Type": "application/json",
+          ...(accessToken ? { Authorization: `Bearer ${accessToken}` } : {}),
+        },
         body: JSON.stringify({
           proofType,
           signerName,


### PR DESCRIPTION
Repairs courier proof saving when the browser session is stored client-side instead of available to the server route as Supabase cookies.

Changes:
- Updates courier proof save API to accept a Supabase Bearer token from the client.
- Keeps cookie-based fallback for existing server route sessions.
- Updates courier proof checklist to send the current Supabase access token when saving proof records.

Why:
- Photo uploads worked because they used the client Supabase session directly.
- Typed signatures could fail because the proof API route depended on server-side cookies and did not always see the logged-in courier session.

Test:
- Merge and deploy.
- Hard refresh courier browser.
- Use a fresh paid/assigned request.
- Save pickup photo, pickup signature, drop-off photo, and drop-off signature.
- Confirm all four rows appear in `exchange_service_proofs`.
- Confirm Mark Delivered unlocks.