### PR TITLE
SafeConnect: allow admin and courier tracking access

### DIFF
--- a/safeconnect/app/track/[id]/page.tsx
+++ b/safeconnect/app/track/[id]/page.tsx
@@ -7,11 +7,13 @@ import ProtectedRoute from "@/components/ProtectedRoute"
 import TrackingMap from "@/components/TrackingMap"
 import { supabase } from "@/lib/supabase"
 
+type ExchangeStatus = "pending" | "assigned" | "picked_up" | "in_transit" | "completed" | "canceled"
+
 type Exchange = {
   id: string
   pickup: string
   dropoff: string
-  status: "pending" | "assigned" | "completed"
+  status: ExchangeStatus
   created_at: string
 }
 
@@ -24,15 +26,10 @@ type TrackingPoint = {
   updated_at: string
 }
 
-function statusClasses(status: Exchange["status"]) {
-  if (status === "pending") {
-    return "badge-pending"
-  }
-
-  if (status === "assigned") {
-    return "badge-active"
-  }
-
+function statusClasses(status: string) {
+  if (status === "pending") return "badge-pending"
+  if (["assigned", "picked_up", "in_transit"].includes(status)) return "badge-active"
+  if (status === "canceled") return "badge-offline"
   return "badge-done"
 }
 
@@ -157,7 +154,7 @@ function LiveTrackingPageContent() {
           )}
         </div>
         <div className="flex items-center gap-2">
-          {exchange && <span className={statusClasses(exchange.status)}>{exchange.status}</span>}
+          {exchange && <span className={statusClasses(exchange.status)}>{exchange.status.replace(/_/g, " ")}</span>}
           <Link href="/request" className="btn-secondary text-sm px-4 py-2">
             Back to Requests
           </Link>
@@ -215,7 +212,7 @@ function LiveTrackingPageContent() {
 
 export default function LiveTrackingPage() {
   return (
-    <ProtectedRoute requiredRole="survivor" loadingLabel="Checking tracking access…">
+    <ProtectedRoute requiredRoles={["survivor", "admin", "courier"]} loadingLabel="Checking tracking access…">
       <LiveTrackingPageContent />
     </ProtectedRoute>
   )

--- a/safeconnect/components/ProtectedRoute.tsx
+++ b/safeconnect/components/ProtectedRoute.tsx
@@ -1,22 +1,30 @@
 "use client"
 
-import { useEffect, useState } from "react"
+import { useEffect, useMemo, useState } from "react"
 import { useRouter } from "next/navigation"
 import { getCurrentUserWithRole, type UserRole } from "@/lib/auth"
 
+type AllowedRole = Exclude<UserRole, null>
+
 type ProtectedRouteProps = {
   children: React.ReactNode
-  requiredRole?: Exclude<UserRole, null>
+  requiredRole?: AllowedRole
+  requiredRoles?: AllowedRole[]
   loadingLabel?: string
 }
 
 export default function ProtectedRoute({
   children,
   requiredRole,
+  requiredRoles,
   loadingLabel = "Checking access…",
 }: ProtectedRouteProps) {
   const router = useRouter()
   const [ready, setReady] = useState(false)
+  const allowedRoles = useMemo(() => {
+    if (requiredRoles?.length) return requiredRoles
+    return requiredRole ? [requiredRole] : []
+  }, [requiredRole, requiredRoles])
 
   useEffect(() => {
     let mounted = true
@@ -33,10 +41,10 @@ export default function ProtectedRoute({
         return
       }
 
-      if (requiredRole && role !== requiredRole) {
+      if (allowedRoles.length > 0 && (!role || !allowedRoles.includes(role))) {
         const params = new URLSearchParams({
           from: window.location.pathname,
-          required: requiredRole,
+          required: allowedRoles.join(","),
         })
         router.replace(`/access-denied?${params.toString()}`)
         return
@@ -50,7 +58,7 @@ export default function ProtectedRoute({
     return () => {
       mounted = false
     }
-  }, [requiredRole, router])
+  }, [allowedRoles, router])
 
   if (!ready) {
     return (


### PR DESCRIPTION
Allows live tracking pages to be viewed by survivor, admin, and courier roles.

Changes:
- Updates ProtectedRoute to accept multiple allowed roles.
- Updates /track/[id] to allow survivor, admin, and courier access.
- Adds safer display for picked_up, in_transit, canceled, and unknown tracking exchange statuses.

Why:
- Admin Proof Viewer links to tracking pages for review.
- Courier may also need to open tracking history.
- The route was previously hard-locked to survivor only, causing Access Denied for admin/courier review.

Test:
- Sign in as survivor and open /track/:id.
- Sign in as admin and open /track/:id from Proof Viewer.
- Sign in as courier and open /track/:id.
- Confirm no Access Denied for those roles.