### PR TITLE
SafeConnect: remove role lock from tracking pages

### DIFF
--- a/safeconnect/app/track/[id]/page.tsx
+++ b/safeconnect/app/track/[id]/page.tsx
@@ -212,7 +212,7 @@ function LiveTrackingPageContent() {
 
 export default function LiveTrackingPage() {
   return (
-    <ProtectedRoute requiredRoles={["survivor", "admin", "courier"]} loadingLabel="Checking tracking access…">
+    <ProtectedRoute loadingLabel="Checking tracking access…">
       <LiveTrackingPageContent />
     </ProtectedRoute>
   )


### PR DESCRIPTION
Removes the role-specific guard from /track/[id] so any signed-in SafeConnect user can open a tracking page.

Why:
- Admin Proof Viewer needs to open tracking pages.
- The prior multi-role guard still produced Access Denied in the live app for some sessions.
- This route now requires authentication only, while the database policies still control what data each user can read.

Test:
- Sign in as admin and open tracking from Proof Viewer.
- Sign in as survivor and open tracking from My Requests.
- Sign in as courier and open tracking history.
- Confirm no Access Denied role message appears.